### PR TITLE
Support for more complex strings with commas and quotes.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,12 +31,32 @@ module.exports = {
 
   parse: function(value, callback) {
     var result = {};
-    var hstore = value.split(',').forEach(function(pair) {
-      var split = pair.split('=>');
-      var key = split[0].replace(/"/g, '').replace(/^\s\s*/, '').replace(/\s\s*$/, '');
-      var value = split[1].replace(/"/g, '');
-      result[key] = value;
-    });
+    var ke = value.length,
+      vs = value.length,
+      ve = value.length,
+      key, val;
+    var buf = '';
+    var i = value.length;
+    //work backwards through string
+    while (i > -1) {
+      buf = value.slice(i - 2, i);
+      if (buf == '=>' || i === 0) {
+        vs = i;
+        ve = (value.lastIndexOf(',') == -1) ? value.length : value.lastIndexOf(',');
+        if (i === 0) {
+          ke = value.indexOf('=>');
+          ve = -1;
+        }
+        if (val) {
+          key = value.slice(ve + 1, ke).trim().slice(1, - 1);
+          value = value.slice(0, ve);
+          result[key] = val;
+        }
+        val = value.slice(vs, value.length).trim().slice(1, - 1);
+        ke = i - 2;
+      }
+      i--;
+    }
     if (!callback || callback === null) return result;
     callback(result);
   }

--- a/test/parse.js
+++ b/test/parse.js
@@ -23,4 +23,31 @@ describe('pg-hstore.parse', function() {
       done();
     });
   });
+  
+  it('should hstore parse an escaped quoted string with quotes', function(done) {
+    var source = '"foo"=>"\"bar\""';
+    hstore.parse(source, function(target) {
+      should.exist(target);
+      target.foo.should.equal('"bar"');
+      done();
+    });
+  });
+  
+  it('should hstore parse a string with commas', function(done) {
+    var source = '"foo"=>"bar,foo,bar"';
+    hstore.parse(source, function(target) {
+      should.exist(target);
+      target.foo.should.equal('bar,foo,bar');
+      done();
+    });
+  });
+  
+  it('should hstore parse a string with advanced types', function(done) {
+    var source = '"foo"=>"{"key":"value","key2":"value"}"';
+    hstore.parse(source, function(target) {
+      should.exist(target);
+      target.foo.should.equal('{"key":"value","key2":"value"}');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
An example of invalid hstores are: "foo"=>"bar,foo,bar" and "foo"=>"\"bar\",\"foo\",\"bar\""

Hope this helps.
