### PR TITLE
Improved double quote and null handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
 var sanitize_input = function(input) {
   // http://www.postgresql.org/docs/9.0/static/sql-syntax-lexical.html [4.1.2.1-4.1.2.2]
   // single quotes (') must be replaced with double single quotes ('')
-  input = input.replace(/'/, '\'\'');
+  input = input.replace(/'/g, '\'\'');
   // backslashes (\) must be replaced with double backslashes (\\)
-  input = input.replace(/\\/, '\\\\');
+  input = input.replace(/\\/g, '\\\\');
+  // double quotes (") must be replaced with escaped quotes (\\")
+  input = input.replace(/"/g, '\\"');
   return input;
 };
 
@@ -22,7 +24,11 @@ var to_string = function(input) {
 module.exports = {
   stringify: function (data, callback) {
     var hstore = Object.keys(data).map(function (key) {
-      return '"'+key+'"=>"'+to_string(data[key])+'"';
+      if (data[key] === null) {
+        return '"'+to_string(key)+'"=>NULL';
+      } else {
+        return '"'+to_string(key)+'"=>"'+to_string(data[key])+'"';
+      }
     });
     var joined = hstore.join();
     if (!callback || callback === null) return joined;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An module for serializing and deserializing JSON data in to hstore format",
   "private": false,
   "keywords": ["pg", "postgres", "hstore"],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "lib/index.js",
   "homepage": "https://github.com/scarney81/pg-hstore",
   "bugs": {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -9,7 +9,6 @@ describe('pg-hstore.stringify', function() {
     hstore.stringify(source, function(target) {
       should.exist(target);
       target.should.equal('"foo"=>"bar"');
-      console.log(target);
       done();
     });
   });
@@ -36,7 +35,43 @@ describe('pg-hstore.stringify', function() {
     var source = { foo: null };
     hstore.stringify(source, function(target) {
       should.exist(target);
-      target.should.equal('"foo"=>""');
+      target.should.equal('"foo"=>NULL');
+      done();
+    });
+  });
+
+  it('should hstore encode a null string value', function(done) {
+    var source = { foo: "null" };
+    hstore.stringify(source, function(target) {
+      should.exist(target);
+      target.should.equal('"foo"=>"null"');
+      done();
+    });
+  });
+
+  it('should hstore encode single quotes correctly', function(done) {
+    var source = { 'foo \'quotes\'': "with \'quotes\'" };
+    hstore.stringify(source, function(target) {
+      should.exist(target);
+      target.should.equal('"foo \'\'quotes\'\'"=>"with \'\'quotes\'\'"');
+      done();
+    });
+  });
+
+  it('should hstore encode double quotes correctly', function(done) {
+    var source = { foo: "with \"quotes\"" };
+    hstore.stringify(source, function(target) {
+      should.exist(target);
+      target.should.equal('"foo"=>"with \\"quotes\\""');
+      done();
+    });
+  });
+
+  it('should hstore encode double quote keys correctly', function(done) {
+    var source = { 'foo \"quotes\"': "with \"quotes\"" };
+    hstore.stringify(source, function(target) {
+      should.exist(target);
+      target.should.equal('"foo \\"quotes\\""=>"with \\"quotes\\""');
       done();
     });
   });


### PR DESCRIPTION
This is an improvement to the stringify function for hstore storage, it changes encoding of JavaScript nulls into the unquoted NULL values and properly escapes double quotes. I might add parsing improvements to handle this as well but for no we're only encoding the values. Thanks for the nice and simple library!
