### PR TITLE
Parsing empty string should return empty object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,10 +57,12 @@
                 return value.replace(/\\"/g, "\"");
             };
 
-        for (i = 0, l = matches.length; i < l; i+= 2) {
+        if(matches) {
+          for (i = 0, l = matches.length; i < l; i+= 2) {
             var key = clean(matches[i]);
             var value = matches[i + 1];
             result[key] = value=="NULL"?null:clean(value);
+          }
         }
         if (!callback || callback === null) return result;
         callback(result);

--- a/test/parse.js
+++ b/test/parse.js
@@ -21,6 +21,15 @@
       });
     });
 
+    it('should hstore parse an empty hstore string', function (done) {
+      var source = '';
+      hstore.parse(source, function (target) {
+        should.exist(target);
+        target.should.eql({});
+        done();
+      });
+    });
+
     it('should hstore parse an hstore string with multiple values', function (done) {
       var source = '"foo"=>"oof","bar"=>"rab","baz"=>"zab"';
       hstore.parse(source, function (target) {


### PR DESCRIPTION
For an empty string parse should return empty object instead of exception "Cannot read property 'length' of null"
