### PR TITLE
Add license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postgres",
     "hstore"
   ],
+  "license": "MIT",
   "version": "2.3.2",
   "main": "lib/index.js",
   "homepage": "https://github.com/scarney81/pg-hstore",


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.